### PR TITLE
Fix some image loading issues.

### DIFF
--- a/libsfil/source/sfil_jpeg.c
+++ b/libsfil/source/sfil_jpeg.c
@@ -6,16 +6,22 @@
 
 static sf2d_texture *_sfil_load_JPEG_generic(struct jpeg_decompress_struct *jinfo, struct jpeg_error_mgr *jerr, sf2d_place place)
 {
-	jpeg_start_decompress(jinfo);
-
 	int row_bytes;
-	switch (jinfo->out_color_space) {
-	case JCS_RGB:
-		row_bytes = jinfo->image_width * 3;
-		break;
-	default:
-		goto exit_error;
+	switch (jinfo->jpeg_color_space) {
+		case JCS_RGB:
+			row_bytes = jinfo->image_width * 3;
+			break;
+		case JCS_YCbCr:
+			// Need to convert this to RGB.
+			jinfo->out_color_space = JCS_RGB;
+			row_bytes = jinfo->image_width * 3;
+			break;
+		default:
+			goto exit_error;
 	}
+
+	// TODO: Support JCS_GRAYSCALE, JCS_CMYK, and JCS_YCCK?
+	jpeg_start_decompress(jinfo);
 
 	sf2d_texture *texture = sf2d_create_texture(jinfo->image_width,
 		jinfo->image_height, GPU_RGBA8, place);

--- a/libsfil/source/sfil_jpeg.c
+++ b/libsfil/source/sfil_jpeg.c
@@ -39,10 +39,10 @@ static sf2d_texture *_sfil_load_JPEG_generic(struct jpeg_decompress_struct *jinf
 	while (jinfo->output_scanline < jinfo->output_height) {
 		jpeg_read_scanlines(jinfo, buffer, 1);
 		unsigned int *tex_ptr = row_ptr;
-		for (i = 0, jpeg_ptr = buffer[0]; i < jinfo->output_width; i++) {
-			color  = *(jpeg_ptr++);
-			color |= *(jpeg_ptr++)<<8;
-			color |= *(jpeg_ptr++)<<16;
+		for (i = 0, jpeg_ptr = buffer[0]; i < jinfo->output_width; i++, jpeg_ptr += 3) {
+			color  = jpeg_ptr[0];
+			color |= jpeg_ptr[1] << 8;
+			color |= jpeg_ptr[2] << 16;
 			*(tex_ptr++) = color | 0xFF000000;
 		}
 		// Next row.

--- a/libsfil/source/sfil_jpeg.c
+++ b/libsfil/source/sfil_jpeg.c
@@ -32,21 +32,21 @@ static sf2d_texture *_sfil_load_JPEG_generic(struct jpeg_decompress_struct *jinf
 	JSAMPARRAY buffer = (JSAMPARRAY)malloc(sizeof(JSAMPROW));
 	buffer[0] = (JSAMPROW)malloc(sizeof(JSAMPLE) * row_bytes);
 
-	unsigned int i, color, *tex_ptr;
-	unsigned char *jpeg_ptr;
-	void *row_ptr = texture->tex.data;
-
-	int stride = texture->tex.width * 4;
+	unsigned int i, color;
+	const unsigned char *jpeg_ptr;
+	unsigned int *row_ptr = texture->tex.data;
 
 	while (jinfo->output_scanline < jinfo->output_height) {
 		jpeg_read_scanlines(jinfo, buffer, 1);
-		tex_ptr = (row_ptr += stride);
+		unsigned int *tex_ptr = row_ptr;
 		for (i = 0, jpeg_ptr = buffer[0]; i < jinfo->output_width; i++) {
-			color = *(jpeg_ptr++);
+			color  = *(jpeg_ptr++);
 			color |= *(jpeg_ptr++)<<8;
 			color |= *(jpeg_ptr++)<<16;
 			*(tex_ptr++) = color | 0xFF000000;
 		}
+		// Next row.
+		row_ptr += texture->tex.width;
 	}
 
 	jpeg_finish_decompress(jinfo);

--- a/libsfil/source/sfil_png.c
+++ b/libsfil/source/sfil_png.c
@@ -63,18 +63,18 @@ static sf2d_texture *_sfil_load_PNG_generic(const void *io_ptr, png_rw_ptr read_
 	if (bit_depth == 8 && color_type == PNG_COLOR_TYPE_RGB)
 		png_set_filler(png_ptr, 0xFF, PNG_FILLER_AFTER);
 
-	if (color_type == PNG_COLOR_TYPE_GRAY ||
-	    color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+	if (color_type == PNG_COLOR_TYPE_GRAY) {
 		png_set_gray_to_rgb(png_ptr);
+		png_set_filler(png_ptr, 0xFF, PNG_FILLER_AFTER);
+	} else if (color_type == PNG_COLOR_TYPE_GRAY_ALPHA) {
+		png_set_gray_to_rgb(png_ptr);
+	}
 
 
 	if (color_type == PNG_COLOR_TYPE_PALETTE) {
 		png_set_palette_to_rgb(png_ptr);
 		png_set_filler(png_ptr, 0xFF, PNG_FILLER_AFTER);
 	}
-
-	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
-		png_set_expand_gray_1_2_4_to_8(png_ptr);
 
 	if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS))
 		png_set_tRNS_to_alpha(png_ptr);


### PR DESCRIPTION
I encountered these issues while working on TWLoader. I originally made a local copy of sfil_png.c for TWLoader to fix the grayscale image issue, but decided to send that fix and these JPEG fixes upstream.

PNG: Fix loading of some grayscale images.
JPEG: Added support for YCbCr images using libjpeg's built-in conversion.
JPEG: Fixed an off-by-one that resulted in the top scanline of loaded images showing up as garbage.